### PR TITLE
fix: missing classes from table

### DIFF
--- a/src/sfdexdl.js
+++ b/src/sfdexdl.js
@@ -3,7 +3,6 @@ let testCoverage = {};
 const overlayDiv = document.createElement('div');
 overlayDiv.className = 'custom-coverage-container';
 overlayDiv.onclick = function(event) {
-    debugger;
     if(event.target.tagName === 'BUTTON') {
         pinOrUnpin(event);
     }
@@ -96,7 +95,7 @@ function getCoverageAndBuildTable() {
         {
             continuation: function(result) {
                 result.records.forEach(record => {
-                    if(record.NumLinesUncovered) {
+                    if(record.NumLinesUncovered + record.NumLinesCovered !== 0) {
                         testCoverage[record.ApexClassOrTrigger.Name] = parseInt(100 * record.NumLinesCovered / (record.NumLinesUncovered + record.NumLinesCovered)) + '%';
                     }
                 })


### PR DESCRIPTION
Replaced the condition, so that the classes having 0 uncovered lines can also be part of the table. But the classes having 0 lines of code would be excluded.